### PR TITLE
Add trim to command string

### DIFF
--- a/CliTerminal.cpp
+++ b/CliTerminal.cpp
@@ -24,6 +24,7 @@ void Cli_Terminal::cli_cal()
             return;
         }
         String command = Serial.readStringUntil((char)10);
+        command.trim();
         Serial.println(command);
         String processed[2];
         *processed = *TextProcessor(command, processed);


### PR DESCRIPTION
The library expects the command to end with a \n.  If the terminal is not able to send only a \n at the end and also sends a \r, the \r becomes a part of the command. This could be handled by adding the \r to the expected command string when creating the command, but it will not work anymore if you want to use the parameters following the command. Then the command string does not have the \r anymore, but it will be appended to the end of the parameters. An therefore the command string does not match the definition of the string anymore.